### PR TITLE
Fix obsoleted QLinkedList<T> and QList::fromStdList<T>

### DIFF
--- a/src/orderedmap.h
+++ b/src/orderedmap.h
@@ -1,5 +1,42 @@
 #ifndef ORDEREDMAP_H
 #define ORDEREDMAP_H
+/***************************************************************************
+ *                                                                         *
+ *   Copyright (C) 2013, 2017-2019 by Mandeep Sandhu                       *
+ *                                         - <mandeepsandhu.chd@gmail.com> *
+ *   Copyright (C) 2022 by Vadim Peretokin - <vperetokin@gmail.com>        *
+ *   Copyright (C) 2022 by Stephen Lyons - <slysven@virginmedia.com>       *
+ *                                                                         *
+ *   All rights reserved.                                                  *
+ *                                                                         *
+ *   Redistribution and use in source and binary forms, with or without    *
+ *   modification, are permitted provided that the following conditions    *
+ *   are met:                                                              *
+ *                                                                         *
+ *     Redistributions of source code must retain the above copyright      *
+ *     notice, this list of conditions and the following disclaimer.       *
+ *                                                                         *
+ *     Redistributions in binary form must reproduce the above copyright   *
+ *     notice, this list of conditions and the following disclaimer in     *
+ *     the documentation and/or other materials provided with the          *
+ *     distribution.                                                       *
+ *                                                                         *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS   *
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT     *
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS     *
+ *   FOR A PARTICULAR PURPOSE ARE  DISCLAIMED. IN NO EVENT SHALL THE       *
+ *   COPYRIGHT *HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, *
+ *   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  *
+ *   BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;      *
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER      *
+ *   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT    *
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN     *
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE       *
+ *   POSSIBILITY OF SUCH DAMAGE.                                           *
+ *                                                                         *
+ ***************************************************************************
+ *                    BSD 2-Clause "Simplified" Licence                    *
+ ***************************************************************************/
 
 #include <QtGlobal>
 #include <QHash>
@@ -34,8 +71,8 @@ class OrderedMap
 {
     class OMHash;
 
-    typedef typename QLinkedList<Key>::iterator QllIterator;
-    typedef typename QLinkedList<Key>::const_iterator QllConstIterator;
+    typedef typename std::list<Key>::iterator QllIterator;
+    typedef typename std::list<Key>::const_iterator QllConstIterator;
     typedef QPair<Value, QllIterator> OMHashValue;
 
     typedef typename OMHash::iterator OMHashIterator;
@@ -337,7 +374,7 @@ private:
     void copy(const OrderedMap<Key, Value> &other);
 
     OMHash data;
-    QLinkedList<Key> insertOrder;
+    std::list<Key> insertOrder;
 };
 
 template <typename Key, typename Value>
@@ -427,7 +464,11 @@ bool OrderedMap<Key, Value>::isEmpty() const
 template<typename Key, typename Value>
 QList<Key> OrderedMap<Key, Value>::keys() const
 {
-    return QList<Key>::fromStdList(insertOrder.toStdList());
+#if (QT_VERSION >= 0x050E00)
+    return QList<Key>(insertOrder.begin(), insertOrder.end());
+#else
+    return QList<Key>::fromStdList(insertOrder);
+#endif
 }
 
 template<typename Key, typename Value>


### PR DESCRIPTION
This is to silence warnings and suggestions to make these changes from Qt 5.15 code - indeed the obsoleted things may not be present in Qt 6.x at all.

I have also added licence details to the particular file I have edited and inserted the copyright of those I have tracked as having made contributions to it in the past.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>